### PR TITLE
Fixes issue #16 ChannelDetail card now links to correct url

### DIFF
--- a/src/components/ChannelCard.jsx
+++ b/src/components/ChannelCard.jsx
@@ -18,7 +18,7 @@ const ChannelCard = ({ channelDetail, marginTop }) => (
       marginTop,
     }}
   >
-    <Link to={`/channel/${channelDetail?.id?.channelId}`}>
+    <Link to={`/channel/${channelDetail?.id?.channelId || channelDetail?.id}`}>
       <CardContent sx={{ display: 'flex', flexDirection: 'column', justifyContent: 'center', textAlign: 'center', color: '#fff' }}>
         <CardMedia
           image={channelDetail?.snippet?.thumbnails?.high?.url || demoProfilePicture}


### PR DESCRIPTION
This fixes #16 
## Cause
The structure of data returned by the API is different for `/search` and `/channels`.
The bug was caused due to handling of data returned by `/search` only. 

## Fix
Added  handling of data returned by `/channels` as well.
```
<Link to={`/channel/${channelDetail?.id?.channelId || channelDetail?.id}`}>
````

https://user-images.githubusercontent.com/26631311/213635213-7480972b-eca3-4628-808a-5cb17d90aea4.mov

