### PR TITLE
update on same set of videos issue (small feature update)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,1 @@
-# Build and Deploy a Modern YouTube Clone Application in React JS with Material UI 5
 
-![YouTube](https://i.ibb.co/4R5RkmW/Thumbnail-5.png)
-
-### Showcase your dev skills with practical experience and land the coding career of your dreams
-💻 JS Mastery Pro - https://jsmastery.pro/youtube
-✅ A special YOUTUBE discount code is automatically applied!
-
-📙 Get the Ultimate Frontend & Backend Development Roadmaps, a Complete JavaScript Cheatsheet, Portfolio Tips, and more - https://www.jsmastery.pro/links

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Build and Deploy a Modern YouTube Clone Application in React JS with Material UI 5
 YouTube
 
+![YouTube](https://i.ibb.co/4R5RkmW/Thumbnail-5.png)
+
 Showcase your dev skills with practical experience and land the coding career of your dreams
 💻 JS Mastery Pro - https://jsmastery.pro/youtube ✅ A special YOUTUBE discount code is automatically applied!
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
+Build and Deploy a Modern YouTube Clone Application in React JS with Material UI 5
+YouTube
 
+Showcase your dev skills with practical experience and land the coding career of your dreams
+💻 JS Mastery Pro - https://jsmastery.pro/youtube ✅ A special YOUTUBE discount code is automatically applied!
+
+📙 Get the Ultimate Frontend & Backend Development Roadmaps, a Complete JavaScript Cheatsheet, Portfolio Tips, and more - https://www.jsmastery.pro/links

--- a/src/components/ChannelDetail.jsx
+++ b/src/components/ChannelDetail.jsx
@@ -17,7 +17,7 @@ const ChannelDetail = () => {
 
       setChannelDetail(data?.items[0]);
 
-      const videosData = await fetchFromAPI(`search?channelId=${id}&part=snippet%2Cid&order=date`);
+      const videosData = await fetchFromAPI(`search?channelId=${id}&part=snippet`,true);
 
       setVideos(videosData?.items);
     };

--- a/src/utils/fetchFromAPI.js
+++ b/src/utils/fetchFromAPI.js
@@ -4,6 +4,7 @@ export const BASE_URL = 'https://youtube-v31.p.rapidapi.com';
 
 let sorting = ["date","relevance","rating","title","viewCount"];
 let sortingIndex = Math.floor(Math.random() * sorting.length);
+
 let countryCodes = ["AF", "AL", "DZ", "AS", "AD", "AO", "AI", "AQ", "AG", "AR", "AM", "AW", "AU", "AT", "AZ", "BS",
                    "BH", "BD", "BB", "BY", "BE", "BZ", "BJ", "BM", "BT", "BO", "BQ", "BA", "BW", "BV", "BR", "IO", "BN",
                    "BG", "BF", "BI", "CV", "KH", "CM", "CA", "KY", "CF", "TD", "CL", "CN", "CX", "CC", "CO", "KM", "CD",
@@ -18,9 +19,9 @@ let countryCodes = ["AF", "AL", "DZ", "AS", "AD", "AO", "AI", "AQ", "AG", "AR", 
                    "KN", "LC", "MF", "PM", "VC", "WS", "SM", "ST", "SA", "SN", "RS", "SC", "SL", "SG", "SX", "SK", "SI", 
                    "SB", "SO", "ZA", "GS", "SS", "ES", "LK", "SD", "SR", "SJ", "SE", "CH", "SY", "TW", "TJ", "TZ", "TH", 
                    "TL", "TG", "TK", "TO", "TT", "TN", "TR", "TM", "TC", "TV", "UG", "UA", "AE", "GB", "UM", "US", "UY", 
-                   "UZ", "VU", "VE", "VN", "VG", "VI", "WF", "EH", "YE", "ZM", "ZW", "AX"]
-let countryIndex = Math.floor(Math.random()*countryCodes.length);
+                   "UZ", "VU", "VE", "VN", "VG", "VI", "WF", "EH", "YE", "ZM", "ZW", "AX"];
 
+let countryIndex = Math.floor(Math.random()*countryCodes.length);
 
 const options = {
   params: {

--- a/src/utils/fetchFromAPI.js
+++ b/src/utils/fetchFromAPI.js
@@ -2,6 +2,26 @@ import axios from 'axios';
 
 export const BASE_URL = 'https://youtube-v31.p.rapidapi.com';
 
+let sorting = ["date","relevance","rating","title","viewCount"];
+let sortingIndex = Math.floor(Math.random() * sorting.length);
+let countryCodes = ["AF", "AL", "DZ", "AS", "AD", "AO", "AI", "AQ", "AG", "AR", "AM", "AW", "AU", "AT", "AZ", "BS",
+                   "BH", "BD", "BB", "BY", "BE", "BZ", "BJ", "BM", "BT", "BO", "BQ", "BA", "BW", "BV", "BR", "IO", "BN",
+                   "BG", "BF", "BI", "CV", "KH", "CM", "CA", "KY", "CF", "TD", "CL", "CN", "CX", "CC", "CO", "KM", "CD",
+                   "CG", "CK", "CR", "HR", "CU", "CW", "CY", "CZ", "CI", "DK", "DJ", "DM", "DO", "EC", "EG", "SV", "GQ",
+                   "ER", "EE", "SZ", "ET", "FK", "FO", "FJ", "FI", "FR", "GF", "PF", "TF", "GA", "GM", "GE", "DE", "GH", 
+                   "GI", "GR", "GL", "GD", "GP", "GU", "GT", "GG", "GN", "GW", "GY", "HT", "HM", "VA", "HN", "HK", "HU", 
+                   "IS", "IN", "ID", "IR", "IQ", "IE", "IM", "IL", "IT", "JM", "JP", "JE", "JO", "KZ", "KE", "KI", "KP", 
+                   "KR", "KW", "KG", "LA", "LV", "LB", "LS", "LR", "LY", "LI", "LT", "LU", "MO", "MG", "MW", "MY", "MV", 
+                   "ML", "MT", "MH", "MQ", "MR", "MU", "YT", "MX", "FM", "MD", "MC", "MN", "ME", "MS", "MA", "MZ", "MM", 
+                   "NA", "NR", "NP", "NL", "NC", "NZ", "NI", "NE", "NG", "NU", "NF", "MP", "NO", "OM", "PK", "PW", "PS", 
+                   "PA", "PG", "PY", "PE", "PH", "PN", "PL", "PT", "PR", "QA", "MK", "RO", "RU", "RW", "RE", "BL", "SH", 
+                   "KN", "LC", "MF", "PM", "VC", "WS", "SM", "ST", "SA", "SN", "RS", "SC", "SL", "SG", "SX", "SK", "SI", 
+                   "SB", "SO", "ZA", "GS", "SS", "ES", "LK", "SD", "SR", "SJ", "SE", "CH", "SY", "TW", "TJ", "TZ", "TH", 
+                   "TL", "TG", "TK", "TO", "TT", "TN", "TR", "TM", "TC", "TV", "UG", "UA", "AE", "GB", "UM", "US", "UY", 
+                   "UZ", "VU", "VE", "VN", "VG", "VI", "WF", "EH", "YE", "ZM", "ZW", "AX"]
+let countryIndex = Math.floor(Math.random()*countryCodes.length);
+
+
 const options = {
   params: {
     maxResults: 50,
@@ -12,7 +32,9 @@ const options = {
   },
 };
 
-export const fetchFromAPI = async (url) => {
+export const fetchFromAPI = async (url,channel) => {
+  options.params.regionCode = countryCodes[countryIndex];
+  options.params.order = !channel?sorting[sortingIndex] : "date";
   const { data } = await axios.get(`${BASE_URL}/${url}`, options);
 
   return data;


### PR DESCRIPTION
On deployment , i noticed same set of videos were returned on each reload because of hardcoded param values  like "date"

This change will broaden the set of videos returned on each reload by ->

1) changing the sorting order from "date" to a mix of "date" , "viewCount" "rating" etc  on random and this change will not reflect on channelDetails page because of the extra parameter taken as an arguement so channelDetails page will only have videos ordered by "date"

2) changing the country codes at random will also generate different set of videos on our feed broadening our pool but this can be considered as an optional change and can be changed as per liking of the mainters

3) please ignore a few changes on readme.md , it was unintentional
